### PR TITLE
Added camera sensors to robot model

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,6 @@ To start run the MORSE simulation of the TUM kitchen with a ScitosA5:
 
   Alternatively:
 
-       $ roslaunch strands_morse tum_kitchen_morse.launch env:=tum_kitchen_with_depthcam
+       $ roslaunch strands_morse tum_kitchen_morse.launch env:=tum_kitchen_WITHOUT_CAMERAS
 
 

--- a/README.md
+++ b/README.md
@@ -73,4 +73,34 @@ To start run the MORSE simulation of the TUM kitchen with a ScitosA5:
 
        $ roslaunch strands_morse tum_kitchen_morse.launch env:=tum_kitchen_WITHOUT_CAMERAS
 
+-----------------
+
+The Scitos robot model is equipped with a video, depth and semantic camera by
+default. 
+
+If you wish to start the robot without any camera provide
+`Scitosa5.WITHOUT_CAMERAS` in the robot's constructor (see example below).
+Starting the robot without any camera is useful to run MORSE in
+<strong>fast_mode</strong>.
+
+If you only want to disable the depth camera, provide
+`Scitosa5.WITHOUT_DEPTHCAM` in the constructor. This might be useful if you run
+MORSE on MacOSX, because users have reported problems when using a depth
+camera.
+
+Example usage in the MORSE builder script:
+
+* with cameras:
+
+        robot = Scitosa5()
+        # Alterntively
+        # robot = Scitosa5(Scitosa5.WITH_CAMERAS)
+
+* without cameras
+                            
+        robot = Scitosa5(Scitosa5.WITHOUT_CAMERAS)
+
+* without depth camera
+        
+        robot = Scitosa5(Scitosa5.WITHOUT_DEPTHCAMS)
 

--- a/strands_sim/src/strands_sim/builder/robots/scitosA5.py
+++ b/strands_sim/src/strands_sim/builder/robots/scitosA5.py
@@ -2,13 +2,14 @@ from morse.builder import *
 
 
 class Scitosa5(Robot):
-    WITH_CAMERAS = True
-    WITHOUT_CAMERAS = False
+    WITH_CAMERAS = 1
+    WITHOUT_DEPTHCAMS = 2
+    WITHOUT_CAMERAS = 3
 
     """
     A template robot model for scitosA5
     """
-    def __init__(self, with_cameras = True):
+    def __init__(self, with_cameras = 1):
 
         # scitosA5.blend is located in the data/robots directory
         Robot.__init__(self, 'strands_sim/robots/scitosA5.blend')
@@ -64,26 +65,28 @@ class Scitosa5(Robot):
         self.scan.create_laser_arc()
         self.scan.add_interface('ros', topic='/scan')
 
-        if with_cameras:
+        if with_cameras < Scitosa5.WITHOUT_CAMERAS:
             self.videocam = VideoCamera()
             self.ptu.append(self.videocam)
             self.videocam.translate(0.04, -0.04, 0.065)
             self.videocam.rotate(0, 0, 0)
             self.videocam.add_interface('ros', topic='/videocam')
-
-            # Depth camera
-            self.depthcam = DepthCamera() # Kinect() RVIZ crashes when depthcam data is visualized!?
-            self.ptu.append(self.depthcam)
-            self.depthcam.translate(0.04, -0.04, 0.065)
-            self.depthcam.rotate(0, 0, 0)
-            self.depthcam.add_interface('ros', topic='/depthcam')
-
+            
             # Semantic Camera
             self.semanticcamera = SemanticCamera()
             self.ptu.append(self.semanticcamera)
             self.semanticcamera.translate(0.04, 0.04, 0.065)
             self.semanticcamera.rotate(0.0, 0.0, 0.0)
             self.semanticcamera.add_interface('ros', topic='/semcam')
+            
+            if with_cameras < Scitosa5.WITHOUT_DEPTHCAMS:
+                # Depth camera
+                self.depthcam = DepthCamera() # Kinect() RVIZ crashes when depthcam data is visualized!?
+                self.ptu.append(self.depthcam)
+                self.depthcam.translate(0.04, -0.04, 0.065)
+                self.depthcam.rotate(0, 0, 0)
+                self.depthcam.add_interface('ros', topic='/depthcam')
+
 
 
 

--- a/strands_sim/src/strands_sim/builder/robots/scitosA5.py
+++ b/strands_sim/src/strands_sim/builder/robots/scitosA5.py
@@ -1,14 +1,18 @@
 from morse.builder import *
 
+
 class Scitosa5(Robot):
+    WITH_CAMERAS = True
+    WITHOUT_CAMERAS = False
+
     """
-    A template robot model for scitosA5, with a motion controller and a pose sensor.
+    A template robot model for scitosA5
     """
-    def __init__(self, debug = True):
+    def __init__(self, with_cameras = True):
 
         # scitosA5.blend is located in the data/robots directory
         Robot.__init__(self, 'strands_sim/robots/scitosA5.blend')
-        #Robot.__init__(self, '/home/lars/work/strands/ranger_sim/data/ranger_sim/robots/ranger.blend')
+
         self.properties(classpath = "strands_sim.robots.scitosA5.Scitosa5")
 
         # The list of the main methods to manipulate your components
@@ -51,8 +55,6 @@ class Scitosa5(Robot):
 
         # Laserscanner
         self.scan = Hokuyo()
-        #scan.translate(x=0.275, z=0.252)
-        #scan.translate(x=0.65, z=-0.60)
         self.scan.translate(x=0.30, z=0.386)
         self.append(self.scan)
         self.scan.properties(Visible_arc = False)
@@ -62,11 +64,26 @@ class Scitosa5(Robot):
         self.scan.create_laser_arc()
         self.scan.add_interface('ros', topic='/scan')
 
-        self.videocam = VideoCamera()
-        self.ptu.append(self.videocam)
-        self.videocam.translate(0.04, -0.04, 0.065)
-        #self.videocam.translate(0.04, -0.04, 1.65)
-        self.videocam.rotate(0, 0, 0)
-        self.videocam.add_interface('ros', topic='/videocam')
+        if with_cameras:
+            self.videocam = VideoCamera()
+            self.ptu.append(self.videocam)
+            self.videocam.translate(0.04, -0.04, 0.065)
+            self.videocam.rotate(0, 0, 0)
+            self.videocam.add_interface('ros', topic='/videocam')
+
+            # Depth camera
+            self.depthcam = DepthCamera() # Kinect() RVIZ crashes when depthcam data is visualized!?
+            self.ptu.append(self.depthcam)
+            self.depthcam.translate(0.04, -0.04, 0.065)
+            self.depthcam.rotate(0, 0, 0)
+            self.depthcam.add_interface('ros', topic='/depthcam')
+
+            # Semantic Camera
+            self.semanticcamera = SemanticCamera()
+            self.ptu.append(self.semanticcamera)
+            self.semanticcamera.translate(0.04, 0.04, 0.065)
+            self.semanticcamera.rotate(0.0, 0.0, 0.0)
+            self.semanticcamera.add_interface('ros', topic='/semcam')
+
 
 

--- a/tum/tum_kitchen_WITHOUT_CAMERAS.py
+++ b/tum/tum_kitchen_WITHOUT_CAMERAS.py
@@ -14,49 +14,50 @@ import random
 #######################b########################################################
 # ROBOT
 ###############################################################################
-robot = Scitosa5()
+
+robot = Scitosa5(Scitosa5.WITHOUT_CAMERAS)
 
 # tum_kitchen
 robot.translate(x=2.5, y=3.2, z=0.0)
-# sandbox
-#robot.translate(1.0, 0.0, 0.0)
-
 
 ###############################################################################
 # SENSORS
 ###############################################################################
+#######################################
+# ADD CAMERA SENSORS MANUALLY IF NEEDED
+#######################################
+
+# ## Video camera
+# videocam = VideoCamera()
+# robot.ptu.append(videocam)
+# videocam.translate(0.04, -0.04, 0.065)
+# videocam.rotate(0, 0, 0)
+# videocam.add_interface('ros', topic='/videocam')
+
+# # Depth Camera
+# depthcam = DepthCamera() # 
+# robot.ptu.append(depthcam)
+# #depthcam.translate(0.04, -0.04, 1.65)
+# depthcam.translate(0.04, -0.04, 0.065)
+# depthcam.rotate(0, 0, 0)
+# depthcam.add_interface('ros', topic='/depthcam')
+
+# # Semantic Camera
+# semanticcamera = SemanticCamera()
+# robot.ptu.append(semanticcamera)
+# #semanticcamera.translate(0.04, 0.04, 1.65)
+# semanticcamera.translate(0.04, 0.04, 0.065)
+# semanticcamera.rotate(0.0, 0.0, 0.0)
+# semanticcamera.add_interface('ros', topic='/semcam')
 
 # Battery discharging rate, in percent per seconds
 # The battery state is published to /battery
-robot.battery.properties(DischargingRate=1.0)
-
-pose = Pose()
-robot.append(pose)
-pose.add_interface('ros', topic='/pose')
-
-ptu_pose = PTUPosture('ptu_pose')
-robot.ptu.append(ptu_pose)
-
-depthcam = DepthCamera() # Kinect() RVIZ crashes when depthcam data is visualized!?
-robot.ptu.append(depthcam)
-#depthcam.translate(0.04, -0.04, 1.65)
-depthcam.translate(0.04, -0.04, 0.065)
-depthcam.rotate(0, 0, 0)
-depthcam.add_interface('ros', topic='/depthcam')
-
-# Semantic Camera
-semanticcamera = SemanticCamera()
-robot.ptu.append(semanticcamera)
-#semanticcamera.translate(0.04, 0.04, 1.65)
-semanticcamera.translate(0.04, 0.04, 0.065)
-semanticcamera.rotate(0.0, 0.0, 0.0)
-semanticcamera.add_interface('ros', topic='/semcam')
+# robot.battery.properties(DischargingRate=1.0)
 
 ###############################################################################
 # OBJECTS
 ###############################################################################
 # cup on counter
-
 
 # table = PassiveObject('environments/tum_kitchen/tum_kitchen','Desk.002')
 # table.properties(Object = True)

--- a/tum/tum_kitchen_WITHOUT_CAMERAS.py
+++ b/tum/tum_kitchen_WITHOUT_CAMERAS.py
@@ -16,6 +16,8 @@ import random
 ###############################################################################
 
 robot = Scitosa5(Scitosa5.WITHOUT_CAMERAS)
+#robot = Scitosa5(Scitosa5.WITHOUT_DEPTHCAMS)
+
 
 # tum_kitchen
 robot.translate(x=2.5, y=3.2, z=0.0)


### PR DESCRIPTION
Now the Scitos robot model is equipped with a video, depth and semantic camera by default. 

If you wish to start the robot without any camera provide `Scitosa5.WITHOUT_CAMERAS` in the robot's constructor (see example below). Starting the robot without any camera is useful to run MORSE in <strong>fast_mode</strong>.

If you only want to disable the depth camera, provide `Scitosa5.WITHOUT_DEPTHCAMS` in the constructor. This might be useful if you run MORSE on MacOSX, because users have reported problems when using a depth camera.

Example usage in the MORSE builder script:
- with cameras:
  
  ```
  robot = Scitosa5()
  # Alterntively
  # robot = Scitosa5(Scitosa5.WITH_CAMERAS)
  ```
- without cameras
  
  ```
  robot = Scitosa5(Scitosa5.WITHOUT_CAMERAS)
  ```
- without depth cameras
  
  ```
  robot = Scitosa5(Scitosa5.WITHOUT_DEPTHCAMS)
  ```

Closes #1 
