### PR TITLE
moved the state publisher from 2d nav launch to morse launch

### DIFF
--- a/bham/launch/bham_cs_morse.launch
+++ b/bham/launch/bham_cs_morse.launch
@@ -1,6 +1,10 @@
 <launch>
   <!-- declare arg to be passed in -->
-  <arg name="env" default="cs_lg"/> 
+  <arg name="env" default="cs_lg"/>
+  
+      <!-- Robot -->
+  <include file="$(find scitos_description)/launch/scitos_state_publisher.launch"/>
 
   <node pkg="strands_morse" type="simulator.sh" respawn="false" name="strands_morse" output="screen" args="bham $(arg env).py"/>
+  
 </launch>

--- a/bham/launch/bham_cs_nav2d.launch
+++ b/bham/launch/bham_cs_nav2d.launch
@@ -2,8 +2,7 @@
   <!-- declare arg to be passed in -->
   <arg name="env" default="cs_lg"/> 
 
-  <!-- Robot -->
-  <include file="$(find scitos_description)/launch/scitos_state_publisher.launch"/>
+
 
   <!-- 2D Navigation -->
   <include file="$(find scitos_2d_navigation)/launch/scitos_2d_nav.launch">

--- a/tum/launch/tum_kitchen_morse.launch
+++ b/tum/launch/tum_kitchen_morse.launch
@@ -1,5 +1,8 @@
 <launch>
   <arg name="env" default="tum_kitchen"/> 
 
+    <!-- Robot -->
+  <include file="$(find scitos_description)/launch/scitos_state_publisher.launch"/>
+  
   <node pkg="strands_morse" type="simulator.sh" respawn="false" name="strands_morse" output="screen" args="tum $(arg env).py"/>
 </launch>

--- a/tum/launch/tum_kitchen_nav2d.launch
+++ b/tum/launch/tum_kitchen_nav2d.launch
@@ -2,8 +2,7 @@
   <!-- declare arg to be passed in -->
   <arg name="env" default="tum_kitchen"/> 
 
-  <!-- Robot -->
-  <include file="$(find scitos_description)/launch/scitos_state_publisher.launch"/>
+
 
   <!-- 2D Navigation -->
   <include file="$(find scitos_2d_navigation)/launch/scitos_2d_nav.launch">

--- a/uol/launch/uol_mht_morse.launch
+++ b/uol/launch/uol_mht_morse.launch
@@ -1,5 +1,8 @@
 <launch>
   <arg name="env" default="uol_mht"/> 
 
+    <!-- Robot -->
+  <include file="$(find scitos_description)/launch/scitos_state_publisher.launch"/>
+  
   <node pkg="strands_morse" type="simulator.sh" respawn="false" name="strands_morse" output="screen" args="uol $(arg env).py"/>
 </launch>

--- a/uol/launch/uol_mht_nav2d.launch
+++ b/uol/launch/uol_mht_nav2d.launch
@@ -2,8 +2,7 @@
   <!-- declare arg to be passed in -->
   <arg name="env" default="uol_mht"/> 
 
-  <!-- Robot -->
-  <include file="$(find scitos_description)/launch/scitos_state_publisher.launch"/>
+
 
   <!-- 2D Navigation -->
   <include file="$(find scitos_2d_navigation)/launch/scitos_2d_nav.launch">


### PR DESCRIPTION
In order for the user to follow the same procedure for launch files in simulation and with the real robot, me and @kunzel were discussing that the state publisher should be launched immediately when morse is called, so that it mirrors the scitos_bringup launch file. Hence, I moved the state publisher launch from the 2d nav to the morse launch.

Before this change, when I was testing the rumblepad based map saver in simulation for example, I always had to launch the state publisher in a different shell, which was an extra step when comparing with the launch procedure I do in the robot
