### PR TITLE
Added node that fakes missing topics in MORSE, e.g. /motor_state

### DIFF
--- a/bham/launch/bham_cs_morse.launch
+++ b/bham/launch/bham_cs_morse.launch
@@ -2,8 +2,8 @@
   <!-- declare arg to be passed in -->
   <arg name="env" default="cs_lg"/>
   
-      <!-- Robot -->
-  <include file="$(find scitos_description)/launch/scitos_state_publisher.launch"/>
+  <!-- Scitos robot -->
+  <include file="$(find strands_morse)/launch/scitos.launch"/>
 
   <node pkg="strands_morse" type="simulator.sh" respawn="false" name="strands_morse" output="screen" args="bham $(arg env).py"/>
   

--- a/launch/scitos.launch
+++ b/launch/scitos.launch
@@ -1,0 +1,7 @@
+<launch>
+  <!-- robot state publisher -->
+  <include file="$(find scitos_description)/launch/scitos_state_publisher.launch"/>
+
+  <!-- scitos node for handling topics and services not provided by MORSE -->
+  <include file="$(find strands_morse)/launch/scitos_node.launch"/>
+</launch>

--- a/launch/scitos_node.launch
+++ b/launch/scitos_node.launch
@@ -1,0 +1,3 @@
+<launch>
+	<node pkg="strands_morse" type="scitos_node.py" name="scitos_node" output="screen"/>
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -23,9 +23,11 @@
   <author email="l.kunze@cs.bham.ac.uk">Lars Kunze</author>
   <author email="cburbridge@gmail.com">Chris Burbridge</author>
   
-  <build_depend>std_msgs</build_depend>
-  <build_depend>rospy</build_depend>
-  
+  <run_depend>std_msgs</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>scitos_msgs</run_depend>
+  <run_depend>scitos_description</run_depend>
+
   <buildtool_depend>catkin</buildtool_depend>
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/strand_morse/scitos_node.py
+++ b/src/strand_morse/scitos_node.py
@@ -1,0 +1,48 @@
+#! /usr/bin/env python
+import roslib; roslib.load_manifest('strands_morse')
+import rospy
+
+# messages
+from scitos_msgs.msg import MotorStatus
+
+# services
+from scitos_msgs.srv import EmergencyStop
+from scitos_msgs.srv import EnableMotors
+from scitos_msgs.srv import ResetOdometry
+from scitos_msgs.srv import ResetMotorStop
+
+
+def emergency_stop():
+    return EmergencyStopResponce()
+
+def enable_motors():
+    return EnableMotorsResponce()
+
+def reset_odometry():
+    return ResetOdometryResponce()
+
+def reset_motorstop():
+    return ResetMotorStopResponce()
+        
+if __name__ == '__main__':
+
+
+    try:
+        rospy.init_node('scitos_node')
+        rospy.loginfo("Starting fake scitos_node")
+        s1 = rospy.Service('emergency_stop', EmergencyStop, emergency_stop)
+        s2 = rospy.Service('enable_motors',  EnableMotors,  enable_motors)
+        s3 = rospy.Service('reset_odometry', ResetOdometry, reset_odometry)
+        s4 = rospy.Service('reset_motorstop',ResetMotorStop,reset_motorstop)
+
+        pub = rospy.Publisher('motor_status', MotorStatus)
+        while not rospy.is_shutdown():
+            msg = MotorStatus()
+            pub.publish(msg)
+            rospy.sleep(1.0)
+            
+        rospy.loginfo("Stopping fake scitos_node")
+    except rospy.ROSInterruptException:
+        pass
+
+

--- a/tum/launch/tum_kitchen_morse.launch
+++ b/tum/launch/tum_kitchen_morse.launch
@@ -1,8 +1,8 @@
 <launch>
   <arg name="env" default="tum_kitchen"/> 
 
-    <!-- Robot -->
-  <include file="$(find scitos_description)/launch/scitos_state_publisher.launch"/>
+  <!-- Scitos robot -->
+  <include file="$(find strands_morse)/launch/scitos.launch"/>
   
   <node pkg="strands_morse" type="simulator.sh" respawn="false" name="strands_morse" output="screen" args="tum $(arg env).py"/>
 </launch>

--- a/uol/launch/uol_mht_morse.launch
+++ b/uol/launch/uol_mht_morse.launch
@@ -1,8 +1,8 @@
 <launch>
   <arg name="env" default="uol_mht"/> 
 
-    <!-- Robot -->
-  <include file="$(find scitos_description)/launch/scitos_state_publisher.launch"/>
+  <!-- Scitos robot -->
+  <include file="$(find strands_morse)/launch/scitos.launch"/>
   
   <node pkg="strands_morse" type="simulator.sh" respawn="false" name="strands_morse" output="screen" args="uol $(arg env).py"/>
 </launch>

--- a/uol/launch/uol_study_restaurant_morse.launch
+++ b/uol/launch/uol_study_restaurant_morse.launch
@@ -1,5 +1,8 @@
 <launch>
   <arg name="env" default="uol_study_restaurant"/> 
 
+  <!-- Scitos robot -->
+  <include file="$(find strands_morse)/launch/scitos.launch"/>
+
   <node pkg="strands_morse" type="simulator.sh" respawn="false" name="strands_morse" output="screen" args="uol $(arg env).py"/>
 </launch>

--- a/uol/launch/uol_study_restaurant_nav2d.launch
+++ b/uol/launch/uol_study_restaurant_nav2d.launch
@@ -2,9 +2,6 @@
   <!-- declare arg to be passed in -->
   <arg name="env" default="uol_study_restaurant"/> 
 
-  <!-- Robot -->
-  <include file="$(find scitos_description)/launch/scitos_state_publisher.launch"/>
-
   <!-- 2D Navigation -->
   <include file="$(find scitos_2d_navigation)/launch/scitos_2d_nav.launch">
       <arg name="map" value="$(find strands_morse)/uol/maps/$(arg env).yaml"/>


### PR DESCRIPTION
Added a simple node (scitos_node) that publishes topics and provides services according to the real robot.

This node runs in parallel to morse and thereby complements it by providing missing topics such as /motor_state.
As this node should be launched whenever the scitos robot is used in MORSE, I added a launch file called scitos.launch, which now bundles the scitos robot state publisher and the scitos_node. I included this new launch file in all existing simulations (bham,tum,uol). That is, future changes wrt to the robot should be realized within scitos.launch instead of the individual environment launch files.

Closes #44 
