### PR TITLE
Add option to ScitosA5 to generate openni stack topics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,17 @@ project(strands_morse)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED roscpp sensor_msgs std_msgs pcl_ros tf message_filters cv_bridge)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 
+find_package(OpenCV REQUIRED)
+
+find_package(PCL REQUIRED)
+include_directories(${PCL_INCLUDE_DIRS})
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
@@ -60,7 +66,7 @@ catkin_package(
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
-# include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 ## Declare a cpp library
 # add_library(strands_morse
@@ -68,16 +74,18 @@ catkin_package(
 # )
 
 ## Declare a cpp executable
-# add_executable(strands_morse_node src/strands_morse_node.cpp)
+add_executable(generate_disparity src/generate_topics/generate_disparity.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
 # add_dependencies(strands_morse_node strands_morse_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
-# target_link_libraries(strands_morse_node
-#   ${catkin_LIBRARIES}
-# )
+target_link_libraries(generate_disparity
+  ${catkin_LIBRARIES}
+  ${PCL_LIBRARIES}
+  ${OpenCV_LIBS}
+)
 
 #############
 ## Install ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(strands_morse)
 
+add_definitions(-std=c++0x)
+
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
@@ -75,6 +77,7 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 ## Declare a cpp executable
 add_executable(generate_disparity src/generate_topics/generate_disparity.cpp)
+add_executable(generate_rgb src/generate_topics/generate_rgb.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
@@ -84,6 +87,11 @@ add_executable(generate_disparity src/generate_topics/generate_disparity.cpp)
 target_link_libraries(generate_disparity
   ${catkin_LIBRARIES}
   ${PCL_LIBRARIES}
+  ${OpenCV_LIBS}
+)
+
+target_link_libraries(generate_rgb
+  ${catkin_LIBRARIES}
   ${OpenCV_LIBS}
 )
 

--- a/launch/generate_camera_topics.launch
+++ b/launch/generate_camera_topics.launch
@@ -1,0 +1,34 @@
+<launch>
+  <arg name="manager" 		default="manager" />
+  <arg name="camera"   		default="head_xtion" />
+  <arg name="machine"   	default="localhost" />
+  <arg name="user"   	default="" />
+  <arg name="publish_tf" default="false" />
+ 
+  <machine name="$(arg machine)" address="$(arg machine)" env-loader="/opt/strands/strands_catkin_ws/devel/env.sh" user="$(arg user)"/>
+  
+  <node pkg="strands_morse" type="generate_rgb" name="generate_rgb" output="screen">
+    <param name="camera" type="string" value="$(arg camera)"/>
+  </node>
+  <node pkg="strands_morse" type="generate_disparity" name="generate_disparity" output="screen">
+    <param name="camera" type="string" value="$(arg camera)"/>
+  </node>
+
+  <!-- Load reasonable defaults for the relative pose between cameras -->
+  <include if="$(arg publish_tf)"
+           file="$(find openni_wrapper)/launch/kinect_frames.launch">
+    <arg name="camera" value="$(arg camera)" />
+    <arg name="machine"  value="$(arg machine)"/>
+  </include>
+
+  <include file="$(find openni_wrapper)/launch/processing.launch">
+    <arg name="camera" value="$(arg camera)" /> 
+    <arg name="manager" value="$(arg manager)_$(arg camera)" /> 
+    <arg name="rgb" value="$(arg camera)/rgb/image_raw" /> 
+    <arg name="depth" value="$(arg camera)/depth/image_raw" />
+    <arg name="rgb_camera_info" value="$(arg camera)/rgb/camera_info" /> 
+    <arg name="depth_camera_info" value="$(arg camera)/depth/camera_info" />  
+    <arg name="machine"  value="$(arg machine)"/>
+  </include>
+
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,25 @@
   <author email="l.kunze@cs.bham.ac.uk">Lars Kunze</author>
   <author email="cburbridge@gmail.com">Chris Burbridge</author>
   
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>pcl_ros</build_depend>
+  <build_depend>libpcl-all-dev</build_depend>
+  <build_depend>tf</build_depend>
+  <build_depend>message_filters</build_depend>
+  <build_depend>cv_bridge</build_depend>
+  <build_depend>OpenCV</build_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>pcl_ros</run_depend>
+  <run_depend>libpcl-all</run_depend>
+  <run_depend>tf</run_depend>
+  <run_depend>message_filters</run_depend>
+  <run_depend>cv_bridge</run_depend>
+  <run_depend>OpenCV</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>tf</run_depend>

--- a/src/generate_topics/generate_disparity.cpp
+++ b/src/generate_topics/generate_disparity.cpp
@@ -119,9 +119,9 @@ int main(int argc, char** argv)
     listener = new tf::TransformListener();
     
     typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image, sensor_msgs::PointCloud2> MySyncPolicy;
-    message_filters::Subscriber<sensor_msgs::Image> image_sub(n, image_input, 1);
-    message_filters::Subscriber<sensor_msgs::PointCloud2> cloud_sub(n, cloud_input, 1);
-    message_filters::Synchronizer<MySyncPolicy> sync(MySyncPolicy(10), image_sub, cloud_sub);
+    message_filters::Subscriber<sensor_msgs::Image> image_sub(n, image_input, 5);
+    message_filters::Subscriber<sensor_msgs::PointCloud2> cloud_sub(n, cloud_input, 5);
+    message_filters::Synchronizer<MySyncPolicy> sync(MySyncPolicy(1), image_sub, cloud_sub);
     sync.registerCallback(&callback);
     
 	//ros::Subscriber sub = n.subscribe(input, 1, callback);

--- a/src/generate_topics/generate_disparity.cpp
+++ b/src/generate_topics/generate_disparity.cpp
@@ -2,105 +2,59 @@
 #include <sensor_msgs/PointCloud2.h>
 #include <pcl_ros/point_cloud.h>
 #include <pcl/point_types.h>
-#include <boost/thread/thread.hpp>
-#include <tf/transform_listener.h>
-#include <message_filters/subscriber.h>
-#include <message_filters/time_synchronizer.h>
-#include <message_filters/sync_policies/approximate_time.h>
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/opencv.hpp>
+#include <sensor_msgs/CameraInfo.h>
 
 ros::Publisher image_pub;
 ros::Publisher cloud_pub;
+ros::Publisher camera_info_pub;
 
-tf::TransformListener* listener;
+ros::Time last_stamp;
+sensor_msgs::CameraInfo cam_info;
+sensor_msgs::ImagePtr image;
+bool initialized;
 
-void callback(const sensor_msgs::Image::ConstPtr& image_msg, const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
+void pcd_callback(const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
 {
-    std::string dest_frame("/head_xtion_rgb_optical_frame");
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>());
     pcl::fromROSMsg(*cloud_msg, *cloud);
     
-    tf::StampedTransform transform;
-    try {
-        //listener->transformPointCloud("/head_xtion_rgb_optical_frame", msg->header.stamp, *msg, msg->header.frame_id, cout);
-        listener->lookupTransform (dest_frame, cloud_msg->header.frame_id, cloud_msg->header.stamp, transform);
-    }
-    catch (tf::TransformException ex) {
-        ROS_INFO("%s",ex.what());
-        return;
-    }
-    
-    tf::Matrix3x3 basis = transform.getBasis();
-    tf::Vector3 origin = transform.getOrigin();
-    
-    Eigen::Matrix3f ebasis;
-    Eigen::Vector3f eorigin;
-    for (size_t i = 0; i < 3; ++i) {
-        eorigin(i) = origin.m_floats[i];
-        for (size_t j = 0; j < 3; ++j) {
-            ebasis(i, j) = basis.getRow(i).m_floats[j];
-        }
-    }
-    
-    // K matrix for /head_xtion/rgb/image_mono
-    //Eigen::Matrix3f K;
-    //K.setZero();
-    //K(0, 0) = 700.0; K(0, 2) = 0.0;
-    //K(1, 1) = 700.0; K(0, 2) = 0.0;
-    //K(2, 2) = 1.0;
-    
-    boost::shared_ptr<sensor_msgs::Image> rgb_tracked_object;
-	cv_bridge::CvImageConstPtr rgb_cv_img_boost_ptr;
-	try {
-		rgb_cv_img_boost_ptr = cv_bridge::toCvShare(*image_msg, rgb_tracked_object);
-	}
-	catch (cv_bridge::Exception& e) {
-		ROS_ERROR("cv_bridge exception: %s", e.what());
-		return;
-	}
-	size_t width = rgb_cv_img_boost_ptr->image.size().width;
-	size_t height = rgb_cv_img_boost_ptr->image.size().height;
+	size_t width = 640;
+	size_t height = 480;
 	cv::Mat temp_depth = cv::Mat::zeros(height, width, CV_16UC1);
     
-    pcl::PointCloud<pcl::PointXYZRGB>::Ptr ccloud(new pcl::PointCloud<pcl::PointXYZRGB>());
     size_t n = cloud->points.size();
-    ccloud->points.resize(n);
     Eigen::Vector3f p;
     int x, y;
-    float f = 700.0; // focal length of /head_xtion/rgb/image_mono
+    uint16_t z, curr_z;
+    float f = 570; // focal length of /head_xtion/rgb/image_mono
     for (size_t i = 0; i < n; ++i) {
-        pcl::PointXYZ& spoint = cloud->points[i];
-        pcl::PointXYZRGB& dpoint = ccloud->points[i];
-        p = eorigin + ebasis*spoint.getVector3fMap();
-        dpoint.getVector3fMap() = p;
-        //p = K*p;
-        //p = 1.0/p(2)*p;
-        x = int(f*p(0)/p(2)) + width/2;
-        y = int(f*p(1)/p(2)) + height/2;
-        
+        p = cloud->points[i].getVector3fMap();
+        x = int(f*p(0)/p(2) + 0.5) + width/2;
+        y = int(f*p(1)/p(2) + 0.5) + height/2;
         if (x >= 0 && x < width && y >= 0 && y < height) {
-            cv::Vec3b bgrPixel = rgb_cv_img_boost_ptr->image.at<cv::Vec3b>(y, x);
-            dpoint.r = bgrPixel[0];
-            dpoint.g = bgrPixel[1];
-            dpoint.b = bgrPixel[2];
-            temp_depth.at<uint16_t>(y, x) = uint16_t(1000.0*p(2));
-        }
-        else {
-            dpoint.r = 255;
-            dpoint.g = 0;
-            dpoint.b = 0;
+            z = uint16_t(1000.0*p(2));
+            curr_z = temp_depth.at<uint16_t>(y, x);
+            if (curr_z == 0 || curr_z > z) {
+                temp_depth.at<uint16_t>(y, x) = z;
+            }
         }
     }
+    cv_bridge::CvImage image_depth = cv_bridge::CvImage(cloud_msg->header, "16UC1", temp_depth);
+    image = image_depth.toImageMsg();
     
-    sensor_msgs::PointCloud2 cout;
-    pcl::toROSMsg(*ccloud, cout);
-    cout.header = cloud_msg->header;
-    cout.header.frame_id = dest_frame;
-    cloud_pub.publish(cout);
-    
-    cv_bridge::CvImage image_depth = cv_bridge::CvImage(image_msg->header, "16UC1", temp_depth);
-    image_pub.publish(image_depth.toImageMsg());
+    cam_info.width = width;
+    cam_info.height = height;
+    cam_info.distortion_model = "plumb_bob";
+    cam_info.K = {{f, 0.0, 320.5, 0.0, f, 240.5, 0.0, 0.0, 1.0}};
+    cam_info.R = {{1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0}};
+    cam_info.P = {{f, 0.0, 320.5, 0.0, 0.0, f, 240.5, 0.0, 0.0, 0.0, 1.0, 0.0}};
+    double D[5] = {0.0,0.0,0.0,0.0,0.0};
+    cam_info.D.assign(&D[0], &D[0]+5);
+    cam_info.header.frame_id = cloud_msg->header.frame_id;
+    cam_info.header.stamp = cloud_msg->header.stamp;
+    initialized = true;
 }
 
 int main(int argc, char** argv)
@@ -109,26 +63,30 @@ int main(int argc, char** argv)
 	ros::NodeHandle n;
 	
 	ros::NodeHandle pn("~");
-	std::string cloud_input;
-    pn.param<std::string>("input", cloud_input, std::string("/head_xtion/depth/points"));
-    std::string image_input;
-    pn.param<std::string>("input", image_input, std::string("/head_xtion/rgb/image_mono"));
-    std::string output;
-    pn.param<std::string>("output", output, std::string("/head_xtion/depth/image"));
+	std::string camera;
+    pn.param<std::string>("camera", camera, std::string("head_xtion"));
+    std::string input = std::string("/") + camera + std::string("/depth/points_raw");
+    std::string output = std::string("/") + camera + std::string("/depth/image_raw");
     
-    listener = new tf::TransformListener();
-    
-    typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image, sensor_msgs::PointCloud2> MySyncPolicy;
-    message_filters::Subscriber<sensor_msgs::Image> image_sub(n, image_input, 5);
-    message_filters::Subscriber<sensor_msgs::PointCloud2> cloud_sub(n, cloud_input, 5);
-    message_filters::Synchronizer<MySyncPolicy> sync(MySyncPolicy(1), image_sub, cloud_sub);
-    sync.registerCallback(&callback);
-    
-	//ros::Subscriber sub = n.subscribe(input, 1, callback);
+	ros::Subscriber sub = n.subscribe(input, 1, pcd_callback);
     image_pub = n.advertise<sensor_msgs::Image>(output, 1);
-    cloud_pub = n.advertise<sensor_msgs::PointCloud2>("/rgb_cloud", 1);
+    camera_info_pub = n.advertise<sensor_msgs::CameraInfo>(std::string("/") + camera + std::string("/depth/camera_info"), 1000);
     
-    ros::spin();
+    initialized = false;
+    ros::Rate rate(20);
+    while (n.ok()) {
+        ros::spinOnce();
+        if (initialized) {
+            ros::Time now = ros::Time::now();
+            ros::Duration duration = now - last_stamp;
+            ros::Time stamp = last_stamp + duration;
+            cam_info.header.stamp = stamp;
+            camera_info_pub.publish(cam_info);
+            image->header.stamp = stamp;
+            image_pub.publish(image);
+        }
+        rate.sleep();
+    }
 	
 	return 0;
 }

--- a/src/generate_topics/generate_disparity.cpp
+++ b/src/generate_topics/generate_disparity.cpp
@@ -1,0 +1,134 @@
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <pcl_ros/point_cloud.h>
+#include <pcl/point_types.h>
+#include <boost/thread/thread.hpp>
+#include <tf/transform_listener.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/opencv.hpp>
+
+ros::Publisher image_pub;
+ros::Publisher cloud_pub;
+
+tf::TransformListener* listener;
+
+void callback(const sensor_msgs::Image::ConstPtr& image_msg, const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
+{
+    std::string dest_frame("/head_xtion_rgb_optical_frame");
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>());
+    pcl::fromROSMsg(*cloud_msg, *cloud);
+    
+    tf::StampedTransform transform;
+    try {
+        //listener->transformPointCloud("/head_xtion_rgb_optical_frame", msg->header.stamp, *msg, msg->header.frame_id, cout);
+        listener->lookupTransform (dest_frame, cloud_msg->header.frame_id, cloud_msg->header.stamp, transform);
+    }
+    catch (tf::TransformException ex) {
+        ROS_INFO("%s",ex.what());
+        return;
+    }
+    
+    tf::Matrix3x3 basis = transform.getBasis();
+    tf::Vector3 origin = transform.getOrigin();
+    
+    Eigen::Matrix3f ebasis;
+    Eigen::Vector3f eorigin;
+    for (size_t i = 0; i < 3; ++i) {
+        eorigin(i) = origin.m_floats[i];
+        for (size_t j = 0; j < 3; ++j) {
+            ebasis(i, j) = basis.getRow(i).m_floats[j];
+        }
+    }
+    
+    // K matrix for /head_xtion/rgb/image_mono
+    //Eigen::Matrix3f K;
+    //K.setZero();
+    //K(0, 0) = 700.0; K(0, 2) = 0.0;
+    //K(1, 1) = 700.0; K(0, 2) = 0.0;
+    //K(2, 2) = 1.0;
+    
+    boost::shared_ptr<sensor_msgs::Image> rgb_tracked_object;
+	cv_bridge::CvImageConstPtr rgb_cv_img_boost_ptr;
+	try {
+		rgb_cv_img_boost_ptr = cv_bridge::toCvShare(*image_msg, rgb_tracked_object);
+	}
+	catch (cv_bridge::Exception& e) {
+		ROS_ERROR("cv_bridge exception: %s", e.what());
+		return;
+	}
+	size_t width = rgb_cv_img_boost_ptr->image.size().width;
+	size_t height = rgb_cv_img_boost_ptr->image.size().height;
+	cv::Mat temp_depth = cv::Mat::zeros(height, width, CV_16UC1);
+    
+    pcl::PointCloud<pcl::PointXYZRGB>::Ptr ccloud(new pcl::PointCloud<pcl::PointXYZRGB>());
+    size_t n = cloud->points.size();
+    ccloud->points.resize(n);
+    Eigen::Vector3f p;
+    int x, y;
+    float f = 700.0; // focal length of /head_xtion/rgb/image_mono
+    for (size_t i = 0; i < n; ++i) {
+        pcl::PointXYZ& spoint = cloud->points[i];
+        pcl::PointXYZRGB& dpoint = ccloud->points[i];
+        p = eorigin + ebasis*spoint.getVector3fMap();
+        dpoint.getVector3fMap() = p;
+        //p = K*p;
+        //p = 1.0/p(2)*p;
+        x = int(f*p(0)/p(2)) + width/2;
+        y = int(f*p(1)/p(2)) + height/2;
+        
+        if (x >= 0 && x < width && y >= 0 && y < height) {
+            cv::Vec3b bgrPixel = rgb_cv_img_boost_ptr->image.at<cv::Vec3b>(y, x);
+            dpoint.r = bgrPixel[0];
+            dpoint.g = bgrPixel[1];
+            dpoint.b = bgrPixel[2];
+            temp_depth.at<uint16_t>(y, x) = uint16_t(1000.0*p(2));
+        }
+        else {
+            dpoint.r = 255;
+            dpoint.g = 0;
+            dpoint.b = 0;
+        }
+    }
+    
+    sensor_msgs::PointCloud2 cout;
+    pcl::toROSMsg(*ccloud, cout);
+    cout.header = cloud_msg->header;
+    cout.header.frame_id = dest_frame;
+    cloud_pub.publish(cout);
+    
+    cv_bridge::CvImage image_depth = cv_bridge::CvImage(image_msg->header, "16UC1", temp_depth);
+    image_pub.publish(image_depth.toImageMsg());
+}
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "generate_disparity");
+	ros::NodeHandle n;
+	
+	ros::NodeHandle pn("~");
+	std::string cloud_input;
+    pn.param<std::string>("input", cloud_input, std::string("/head_xtion/depth/points"));
+    std::string image_input;
+    pn.param<std::string>("input", image_input, std::string("/head_xtion/rgb/image_mono"));
+    std::string output;
+    pn.param<std::string>("output", output, std::string("/head_xtion/depth/image"));
+    
+    listener = new tf::TransformListener();
+    
+    typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image, sensor_msgs::PointCloud2> MySyncPolicy;
+    message_filters::Subscriber<sensor_msgs::Image> image_sub(n, image_input, 1);
+    message_filters::Subscriber<sensor_msgs::PointCloud2> cloud_sub(n, cloud_input, 1);
+    message_filters::Synchronizer<MySyncPolicy> sync(MySyncPolicy(10), image_sub, cloud_sub);
+    sync.registerCallback(&callback);
+    
+	//ros::Subscriber sub = n.subscribe(input, 1, callback);
+    image_pub = n.advertise<sensor_msgs::Image>(output, 1);
+    cloud_pub = n.advertise<sensor_msgs::PointCloud2>("/rgb_cloud", 1);
+    
+    ros::spin();
+	
+	return 0;
+}

--- a/src/generate_topics/generate_rgb.cpp
+++ b/src/generate_topics/generate_rgb.cpp
@@ -1,0 +1,50 @@
+#include <ros/ros.h>
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/opencv.hpp>
+#include <sensor_msgs/CameraInfo.h>
+
+ros::Publisher image_pub;
+ros::Publisher camera_info_pub;
+
+void img_callback(const sensor_msgs::Image::ConstPtr& image_msg)
+{
+    size_t width = 640;
+	size_t height = 480;
+    image_pub.publish(image_msg);
+    
+    // ros camera parameters
+    sensor_msgs::CameraInfo info;
+    info.width = width;
+    info.height = height;
+    info.distortion_model = "plumb_bob";
+    info.K = {{525.0, 0.0, 319.5, 0.0, 525.0, 239.5, 0.0, 0.0, 1.0}};
+    info.R = {{1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0}};
+    info.P = {{525.0, 0.0, 319.5, 0.0, 0.0, 525.0, 239.5, 0.0, 0.0, 0.0, 1.0, 0.0}};
+    double D[5] = {0.0,0.0,0.0,0.0,0.0};
+    info.D.assign(&D[0], &D[0]+5);
+    info.header.frame_id = image_msg->header.frame_id;
+    info.header.stamp = image_msg->header.stamp;
+    
+    camera_info_pub.publish(info);
+}
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "generate_rgb");
+	ros::NodeHandle n;
+	
+	ros::NodeHandle pn("~");
+    std::string image_input;
+    std::string camera;
+    pn.param<std::string>("camera", camera, std::string("head_xtion"));
+    std::string input = std::string("/") + camera + std::string("/rgb8/image_raw");
+    std::string output = std::string("/") + camera + std::string("/rgb/image_raw");
+    
+    ros::Subscriber sub = n.subscribe(input, 1, img_callback);
+    image_pub = n.advertise<sensor_msgs::Image>(output, 1);
+    camera_info_pub = n.advertise<sensor_msgs::CameraInfo>(std::string("/") + camera + std::string("/rgb/camera_info"), 1000);
+    
+    ros::spin();
+	
+	return 0;
+}

--- a/src/generate_topics/generate_rgb.cpp
+++ b/src/generate_topics/generate_rgb.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv)
     std::string image_input;
     std::string camera;
     pn.param<std::string>("camera", camera, std::string("head_xtion"));
-    std::string input = std::string("/") + camera + std::string("/rgb8/image_raw");
+    std::string input = std::string("/") + camera + std::string("/rgb8/image_mono");
     std::string output = std::string("/") + camera + std::string("/rgb/image_raw");
     
     ros::Subscriber sub = n.subscribe(input, 1, img_callback);

--- a/strands_sim/src/strands_sim/builder/robots/scitosA5.py
+++ b/strands_sim/src/strands_sim/builder/robots/scitosA5.py
@@ -14,10 +14,10 @@ class Scitosa5(Robot):
     PTU_POSE_TOPIC        = '/ptu/state'
     BATTERY_TOPIC         = '/battery_state'
     SCAN_TOPIC            = '/scan'
-    VIDEOCAM_TOPIC        = '/head_xtion/rgb'
-    VIDEOCAM_TOPIC_SUFFIX = '/image_mono'
+    VIDEOCAM_TOPIC        = '/head_xtion/rgb8'
+    VIDEOCAM_TOPIC_SUFFIX = '/image_raw'
     SEMANTICCAM_TOPIC     = '/semcam'
-    DEPTHCAM_TOPIC        = '/head_xtion/depth/points'
+    DEPTHCAM_TOPIC        = '/head_xtion/depth/points_raw'
 
     # frame id's
     DEPTHCAM_FRAME_ID = '/head_xtion_depth_optical_frame'
@@ -97,8 +97,8 @@ class Scitosa5(Robot):
             self.ptu.append(self.videocam)
             self.videocam.translate(0.00, -0.045, 0.0945)
             self.videocam.rotate(0, 0, 0)
-            self.videocam.properties(cam_width=640, cam_height=480)
-            self.videocam.frequency(30)
+            self.videocam.properties(cam_width=640, cam_height=480, cam_focal=26.25)
+            self.videocam.frequency(20)
             self.videocam.add_interface('ros',
                                         topic= Scitosa5.VIDEOCAM_TOPIC,
                                         topic_suffix= Scitosa5.VIDEOCAM_TOPIC_SUFFIX,
@@ -125,9 +125,9 @@ class Scitosa5(Robot):
                 self.depthcam.properties(cam_near = 0.1)
 
                 # workaround for point cloud with offset
-                self.depthcam.properties(cam_width = 128, cam_height = 128)
-                bpy.context.scene.render.resolution_x = 128
-                bpy.context.scene.render.resolution_y = 128
+                self.depthcam.properties(cam_width = 640, cam_height = 480, cam_focal = 28.5)
+                bpy.context.scene.render.resolution_x = 640
+                bpy.context.scene.render.resolution_y = 480
 
                 self.depthcam.rotate(0, 0, 0)
                 self.depthcam.add_interface('ros', topic= Scitosa5.DEPTHCAM_TOPIC, frame_id= Scitosa5.DEPTHCAM_FRAME_ID, tf='False')

--- a/strands_sim/src/strands_sim/builder/robots/scitosA5.py
+++ b/strands_sim/src/strands_sim/builder/robots/scitosA5.py
@@ -3,6 +3,7 @@ from morse.builder.bpymorse import *
 
 class Scitosa5(Robot):
     # camera configuration
+    WITH_OPENNI = 0
     WITH_CAMERAS = 1
     WITHOUT_DEPTHCAMS = 2
     WITHOUT_CAMERAS = 3
@@ -14,10 +15,10 @@ class Scitosa5(Robot):
     PTU_POSE_TOPIC        = '/ptu/state'
     BATTERY_TOPIC         = '/battery_state'
     SCAN_TOPIC            = '/scan'
-    VIDEOCAM_TOPIC        = '/head_xtion/rgb8'
+    VIDEOCAM_TOPIC        = '/head_xtion/rgb'
     VIDEOCAM_TOPIC_SUFFIX = '/image_raw'
     SEMANTICCAM_TOPIC     = '/semcam'
-    DEPTHCAM_TOPIC        = '/head_xtion/depth/points_raw'
+    DEPTHCAM_TOPIC        = '/head_xtion/depth/points'
 
     # frame id's
     DEPTHCAM_FRAME_ID = '/head_xtion_depth_optical_frame'
@@ -28,6 +29,9 @@ class Scitosa5(Robot):
     A template robot model for scitosA5
     """
     def __init__(self, with_cameras = 1):
+        if with_cameras == Scitosa5.WITH_OPENNI:
+            Scitosa5.VIDEOCAM_TOPIC        = '/head_xtion/rgb8'
+            Scitosa5.DEPTHCAM_TOPIC        = '/head_xtion/depth/points_raw'
 
         # scitosA5.blend is located in the data/robots directory
         Robot.__init__(self, 'strands_sim/robots/scitos.blend')
@@ -97,8 +101,12 @@ class Scitosa5(Robot):
             self.ptu.append(self.videocam)
             self.videocam.translate(0.00, -0.045, 0.0945)
             self.videocam.rotate(0, 0, 0)
-            self.videocam.properties(cam_width=640, cam_height=480, cam_focal=26.25)
-            self.videocam.frequency(20)
+            if with_cameras == Scitosa5.WITH_OPENNI:
+                self.videocam.properties(cam_width=640, cam_height=480, cam_focal=26.25)
+                self.videocam.frequency(20)
+            else:
+                self.videocam.properties(cam_width=640, cam_height=480)
+                self.videocam.frequency(30)
             self.videocam.add_interface('ros',
                                         topic= Scitosa5.VIDEOCAM_TOPIC,
                                         topic_suffix= Scitosa5.VIDEOCAM_TOPIC_SUFFIX,
@@ -125,9 +133,14 @@ class Scitosa5(Robot):
                 self.depthcam.properties(cam_near = 0.1)
 
                 # workaround for point cloud with offset
-                self.depthcam.properties(cam_width = 640, cam_height = 480, cam_focal = 28.5)
-                bpy.context.scene.render.resolution_x = 640
-                bpy.context.scene.render.resolution_y = 480
+                if with_cameras == Scitosa5.WITH_OPENNI:
+                    self.depthcam.properties(cam_width = 640, cam_height = 480, cam_focal = 28.5)
+                    bpy.context.scene.render.resolution_x = 640
+                    bpy.context.scene.render.resolution_y = 480
+                else:
+                    self.depthcam.properties(cam_width = 128, cam_height = 128)
+                    bpy.context.scene.render.resolution_x = 128
+                    bpy.context.scene.render.resolution_y = 128
 
                 self.depthcam.rotate(0, 0, 0)
                 self.depthcam.add_interface('ros', topic= Scitosa5.DEPTHCAM_TOPIC, frame_id= Scitosa5.DEPTHCAM_FRAME_ID, tf='False')

--- a/strands_sim/src/strands_sim/builder/robots/scitosA5.py
+++ b/strands_sim/src/strands_sim/builder/robots/scitosA5.py
@@ -16,7 +16,7 @@ class Scitosa5(Robot):
     BATTERY_TOPIC         = '/battery_state'
     SCAN_TOPIC            = '/scan'
     VIDEOCAM_TOPIC        = '/head_xtion/rgb'
-    VIDEOCAM_TOPIC_SUFFIX = '/image_raw'
+    VIDEOCAM_TOPIC_SUFFIX = '/image_mono'
     SEMANTICCAM_TOPIC     = '/semcam'
     DEPTHCAM_TOPIC        = '/head_xtion/depth/points'
 


### PR DESCRIPTION
This adds a few things to be able to get all the topics of the normal openni camera in the simulator. The main drawback is that simulating the cameras in morse at this size and frequency is costly. However, I've found it to work out ok. The original settings are used if you do not set the flag when creating the robot. To run:
- Create a Scitosa5 robot in your scene with `Scitosa5(with_cameras = Scitosa5.WITH_OPENNI)`
- Launch `roslaunch strands_morse generate_camera_topics.launch`

If @kunzel could have a look at these changes before they are merge that would be great.
