### PR TITLE
Using the standard morse human model

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ For running the simulation you would need:
 * [Blender](http://www.blender.org/download/get-blender/)
 * [ROS](http://www.ros.org/wiki/ROS/Installation)
 
+We recommend to install the morse-blender-bundle from our debian server:
+
+* Set-up instructions: [Using the STRANDS repository](https://github.com/strands-project-releases/strands-releases/wiki#using-the-strands-repository)
+* Install the bundle: `sudo apt-get install morse-blender-2.65-py-3.3`
+* Source the environment: `source /opt/morse-blender-2.65-py-3.3/.bashrc` _You might want to add this to your ~/.bashrc_
+* Check if morse has installed correctly: `morse check`
+
 Please refer to the respective installation guides to install them on your system. 
 
 The current software has been tested under the following configuration:

--- a/uol/uol_mht_human.py
+++ b/uol/uol_mht_human.py
@@ -28,7 +28,7 @@ rpose.add_stream('ros', method="morse.middleware.ros.pose.TFPublisher", frame_id
 # The bateery state is published to /battery
 robot.battery.properties(DischargingRate=1.0)
 
-human=HumanStrands()
+human=Human()
 human.use_world_camera()
 human.translate(x=4.5, y=3.2, z=0.1)
 human.properties(Object = True)


### PR DESCRIPTION
Fixing #79 

Major difference: the standard human only has a rectangular bounding box and no separate cylinders for legs. Therefore leg detectors won't work.

This is just a temporary fix.

Also added set-up instructions using the `morse-blender-bundle`.
