### PR TITLE
Added openni_wrapper as a run dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -51,6 +51,7 @@
   <run_depend>topic_republisher</run_depend>
   <run_depend>scitos_msgs</run_depend>
   <run_depend>scitos_description</run_depend>
+  <run_depend>openni_wrapper</run_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
 


### PR DESCRIPTION
Added `openni_wrapper` as a run dependency since `generate_camera_topics.launch` uses it.
