### PR TITLE
changed AAF sim to use full-scale openNI simulation 

### DIFF
--- a/aaf/aaf.py
+++ b/aaf/aaf.py
@@ -9,7 +9,7 @@ from morse.builder import *
 from strands_sim.builder.robots import Scitosa5
 
 #robot = Ranger()
-robot = Scitosa5()
+robot = Scitosa5(with_cameras=Scitosa5.WITH_OPENNI)
 
 # tum_kitchen
 robot.translate(x=-1.5, y=0.0, z=0.1)

--- a/aaf/aaf_sim.py
+++ b/aaf/aaf_sim.py
@@ -9,7 +9,7 @@ from morse.builder import *
 from strands_sim.builder.robots import Scitosa5
 
 #robot = Ranger()
-robot = Scitosa5()
+robot = Scitosa5(with_cameras=Scitosa5.WITH_OPENNI)
 
 # tum_kitchen
 robot.translate(x=0.3, y=0.0, z=0.1)

--- a/aaf/launch/aaf_sim_morse.launch
+++ b/aaf/launch/aaf_sim_morse.launch
@@ -3,7 +3,9 @@
 
   <!-- Scitos robot -->
   <include file="$(find strands_morse)/launch/scitos.launch"/>
+  <include file="$(find strands_morse)/launch/generate_camera_topics.launch" />	
   
   <node pkg="strands_morse" type="simulator.sh" respawn="false" name="strands_morse" output="screen" args="aaf $(arg env).py"/>
 
-</launch>
+
+</launch>	

--- a/launch/generate_camera_topics.launch
+++ b/launch/generate_camera_topics.launch
@@ -5,7 +5,6 @@
   <arg name="user"   	default="" />
   <arg name="publish_tf" default="false" />
  
-  <machine name="$(arg machine)" address="$(arg machine)" env-loader="/opt/strands/strands_catkin_ws/devel/env.sh" user="$(arg user)"/>
   
   <node pkg="strands_morse" type="generate_rgb" name="generate_rgb" output="screen">
     <param name="camera" type="string" value="$(arg camera)"/>


### PR DESCRIPTION
Thanks to #68 we can now do this and we should, to have all the image topics also in simulation. Thanks @nilsbore for this, but I had to also fix one thing in e7b6257f1ce892e15e591e8005a1768a23e9473d where I removed the machine tags from `generate_camera_topics.launch`. I think they are not needed, but I just want to confirm with @nilsbore.

Also, @Jailander, please comment if you think this is useful or has any side effects. I tested it locally and it's brilliant :smirk: 

apologies for the slightly off branch name...
